### PR TITLE
Fix ContainedBy definition

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ mod dsl {
         diesel_infix_operator!(And, " && ", TsQuery, backend: Pg);
         diesel_infix_operator!(Or, " || ", TsQuery, backend: Pg);
         diesel_infix_operator!(Contains, " @> ", backend: Pg);
-        diesel_infix_operator!(ContainedBy, " @> ", backend: Pg);
+        diesel_infix_operator!(ContainedBy, " <@ ", backend: Pg);
     }
 
     use self::predicates::*;


### PR DESCRIPTION
Should be `<@`, per https://www.postgresql.org/docs/9.1/static/functions-textsearch.html#TEXTSEARCH-OPERATORS-TABLE.