### PR TITLE
Add repository link to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "1.0.0"
 authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 description = "Adds support for PostgreSQL full text search to Diesel"
 license = "MIT"
+repository = "https://github.com/diesel-rs/diesel_full_text_search"
 
 [dependencies]
 diesel = { version = "1.0", features = ["postgres"] }


### PR DESCRIPTION
Just tried to get here from crates.io and found out the repo link isn't there