### PR TITLE
Add setweight function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ mod functions {
     sql_function!(ts_headline, ts_headline_t, (x: Text, y: TsQuery) -> Text);
     sql_function!(ts_rank, ts_rank_t, (x: TsVector, y: TsQuery) -> Float);
     sql_function!(ts_rank_cd, ts_rank_cd_t, (x: TsVector, y: TsQuery) -> Float);
+    sql_function!(setweight, setweight_t, (x: TsVector, y: Text) -> TsVector);
 }
 
 mod dsl {


### PR DESCRIPTION
A simplification of #4 without the ts_rank variants. This PR simply adds the setweight function of Postgres' fulltext search.