### PR TITLE
Added a nullable Text field support and Regconfig struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 extern crate diesel;
 
 mod types {
+    use diesel::sql_types::*;
+
     #[allow(deprecated)]
     use diesel::SqlType;
 
@@ -13,6 +15,11 @@ mod types {
     #[postgres(oid = "3614", array_oid = "3643")]
     pub struct TsVector;
     pub type Tsvector = TsVector;
+
+    pub trait TextOrNullableText {}
+
+    impl TextOrNullableText for Text {}
+    impl TextOrNullableText for Nullable<Text> {}
 
     #[derive(SqlType)]
     #[postgres(type_name = "regconfig")]
@@ -30,26 +37,28 @@ pub mod configuration {
     use diesel::sql_types::Integer;
     use diesel::types::ToSql;
 
-    pub const CONFIGURATION_SIMPLE: u32 = 3748;
-    pub const CONFIGURATION_DANISH: u32 = 12824;
-    pub const CONFIGURATION_DUTCH: u32 = 12826;
-    pub const CONFIGURATION_ENGLISH: u32 = 12828;
-    pub const CONFIGURATION_FINNISH: u32 = 12830;
-    pub const CONFIGURATION_FRENCH: u32 = 12832;
-    pub const CONFIGURATION_GERMAN: u32 = 12834;
-    pub const CONFIGURATION_HUNGARIAN: u32 = 12836;
-    pub const CONFIGURATION_ITALIAN: u32 = 12838;
-    pub const CONFIGURATION_NORWEGIAN: u32 = 12840;
-    pub const CONFIGURATION_PORTUGUESE: u32 = 12842;
-    pub const CONFIGURATION_ROMANIAN: u32 = 12844;
-    pub const CONFIGURATION_RUSSIAN: u32 = 12846;
-    pub const CONFIGURATION_SPANISH: u32 = 12848;
-    pub const CONFIGURATION_SWEDISH: u32 = 12850;
-    pub const CONFIGURATION_TURKISH: u32 = 12852;
-
     #[derive(Debug, PartialEq, AsExpression)]
     #[sql_type = "Regconfig"]
     pub struct TsConfiguration(pub u32);
+
+    impl TsConfiguration {
+        pub const SIMPLE: Self = Self(3748);
+        pub const DANISH: Self = Self(12824);
+        pub const DUTCH: Self = Self(12826);
+        pub const ENGLISH: Self = Self(12828);
+        pub const FINNISH: Self = Self(12830);
+        pub const FRENCH: Self = Self(12832);
+        pub const GERMAN: Self = Self(12834);
+        pub const HUNGARIAN: Self = Self(12836);
+        pub const ITALIAN: Self = Self(12838);
+        pub const NORWEGIAN: Self = Self(12840);
+        pub const PORTUGUESE: Self = Self(12842);
+        pub const ROMANIAN: Self = Self(12844);
+        pub const RUSSIAN: Self = Self(12846);
+        pub const SPANISH: Self = Self(12848);
+        pub const SWEDISH: Self = Self(12850);
+        pub const TURKISH: Self = Self(12852);
+    }
 
     impl<DB> FromSql<Regconfig, DB> for TsConfiguration
     where
@@ -87,15 +96,10 @@ mod functions {
         #[sql_name = "to_tsquery"]
         fn to_tsquery_with_search_config(config: Regconfig, querytext: Text) -> TsQuery;
     }
-    sql_function!(fn to_tsvector(x: Text) -> TsVector);
-    sql_function!(fn nullableto_tsvector(x: Nullable<Text>) -> TsVector);
+    sql_function!(fn to_tsvector<T: TextOrNullableText>(x: T) -> TsVector);
     sql_function! {
         #[sql_name = "to_tsvector"]
-        fn to_tsvector_with_search_config(config: Regconfig, document_content: Text) -> TsVector;
-    }
-    sql_function! {
-        #[sql_name = "to_tsvector"]
-        fn nullableto_tsvector_with_search_config(config: Regconfig, document_content: Nullable<Text>) -> TsVector;
+        fn to_tsvector_with_search_config<T: TextOrNullableText>(config: Regconfig, document_content: T) -> TsVector;
     }
     sql_function!(fn ts_headline(x: Text, y: TsQuery) -> Text);
     sql_function!(fn ts_rank(x: TsVector, y: TsQuery) -> Float);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,14 +2,6 @@
 extern crate diesel;
 
 mod types {
-    use std::io::Write;
-
-    use diesel::backend::Backend;
-    use diesel::deserialize::{self, FromSql};
-    use diesel::serialize::{self, Output};
-    use diesel::sql_types::Integer;
-    use diesel::types::ToSql;
-
     #[allow(deprecated)]
     use diesel::SqlType;
 
@@ -21,6 +13,22 @@ mod types {
     #[postgres(oid = "3614", array_oid = "3643")]
     pub struct TsVector;
     pub type Tsvector = TsVector;
+
+    #[derive(SqlType)]
+    #[postgres(type_name = "regconfig")]
+    pub struct Regconfig;
+}
+
+pub mod configuration {
+    use crate::Regconfig;
+
+    use std::io::Write;
+
+    use diesel::backend::Backend;
+    use diesel::deserialize::{self, FromSql};
+    use diesel::serialize::{self, Output};
+    use diesel::sql_types::Integer;
+    use diesel::types::ToSql;
 
     pub const CONFIGURATION_SIMPLE: u32 = 3748;
     pub const CONFIGURATION_DANISH: u32 = 12824;
@@ -39,13 +47,9 @@ mod types {
     pub const CONFIGURATION_SWEDISH: u32 = 12850;
     pub const CONFIGURATION_TURKISH: u32 = 12852;
 
-    #[derive(SqlType)]
-    #[postgres(type_name = "regconfig")]
-    pub struct Regconfig;
-
     #[derive(Debug, PartialEq, AsExpression)]
     #[sql_type = "Regconfig"]
-    pub struct TsConfiguration(u32);
+    pub struct TsConfiguration(pub u32);
 
     impl<DB> FromSql<Regconfig, DB> for TsConfiguration
     where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,14 @@
 extern crate diesel;
 
 mod types {
+    use std::io::Write;
+
+    use diesel::backend::Backend;
+    use diesel::deserialize::{self, FromSql};
+    use diesel::serialize::{self, Output};
+    use diesel::sql_types::Integer;
+    use diesel::types::ToSql;
+
     #[allow(deprecated)]
     use diesel::SqlType;
 
@@ -14,9 +22,50 @@ mod types {
     pub struct TsVector;
     pub type Tsvector = TsVector;
 
+    pub const CONFIGURATION_SIMPLE: u32 = 3748;
+    pub const CONFIGURATION_DANISH: u32 = 12824;
+    pub const CONFIGURATION_DUTCH: u32 = 12826;
+    pub const CONFIGURATION_ENGLISH: u32 = 12828;
+    pub const CONFIGURATION_FINNISH: u32 = 12830;
+    pub const CONFIGURATION_FRENCH: u32 = 12832;
+    pub const CONFIGURATION_GERMAN: u32 = 12834;
+    pub const CONFIGURATION_HUNGARIAN: u32 = 12836;
+    pub const CONFIGURATION_ITALIAN: u32 = 12838;
+    pub const CONFIGURATION_NORWEGIAN: u32 = 12840;
+    pub const CONFIGURATION_PORTUGUESE: u32 = 12842;
+    pub const CONFIGURATION_ROMANIAN: u32 = 12844;
+    pub const CONFIGURATION_RUSSIAN: u32 = 12846;
+    pub const CONFIGURATION_SPANISH: u32 = 12848;
+    pub const CONFIGURATION_SWEDISH: u32 = 12850;
+    pub const CONFIGURATION_TURKISH: u32 = 12852;
+
     #[derive(SqlType)]
     #[postgres(type_name = "regconfig")]
     pub struct Regconfig;
+
+    #[derive(Debug, PartialEq, AsExpression)]
+    #[sql_type = "Regconfig"]
+    pub struct TsConfiguration(u32);
+
+    impl<DB> FromSql<Regconfig, DB> for TsConfiguration
+    where
+        DB: Backend,
+        i32: FromSql<Integer, DB>,
+    {
+        fn from_sql(bytes: Option<&DB::RawValue>) -> deserialize::Result<Self> {
+            <i32 as FromSql<Integer, DB>>::from_sql(bytes).map(|oid| TsConfiguration(oid as u32))
+        }
+    }
+
+    impl<DB> ToSql<Regconfig, DB> for TsConfiguration
+    where
+        DB: Backend,
+        i32: ToSql<Integer, DB>,
+    {
+        fn to_sql<W: Write>(&self, out: &mut Output<W, DB>) -> serialize::Result {
+            <i32 as ToSql<Integer, DB>>::to_sql(&(*&self.0 as i32), out)
+        }
+    }
 }
 
 #[allow(deprecated)]


### PR DESCRIPTION
In this PR I implemented a basic `TsConfigurarion` structure with some predefined constants that are useful to use all the Postgres full text search functionalities.

Also, I added two additional useful methods for `Nullable<Text>` support.