### PR TITLE
Update diesel dependency and address breaking changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,4 @@ license = "MIT"
 repository = "https://github.com/diesel-rs/diesel_full_text_search"
 
 [dependencies]
-diesel = { version = "1.3.0", features = ["postgres"] }
+diesel = { git = "https://github.com/diesel-rs/diesel", rev = "6eae69f3e60b45c383927336b48b6ee860a71e00", features = ["postgres"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ mod types {
     pub struct TsVector;
     pub type Tsvector = TsVector;
 
-    pub trait TextOrNullableText {}
+    pub trait TextOrNullableText: SingleValue {}
 
     impl TextOrNullableText for Text {}
     impl TextOrNullableText for Nullable<Text> {}
@@ -31,11 +31,10 @@ pub mod configuration {
 
     use std::io::Write;
 
-    use diesel::backend::Backend;
+    use diesel::backend::{Backend, RawValue};
     use diesel::deserialize::{self, FromSql};
-    use diesel::serialize::{self, Output};
+    use diesel::serialize::{self, Output, ToSql};
     use diesel::sql_types::Integer;
-    use diesel::types::ToSql;
 
     #[derive(Debug, PartialEq, AsExpression)]
     #[sql_type = "Regconfig"]
@@ -65,7 +64,7 @@ pub mod configuration {
         DB: Backend,
         i32: FromSql<Integer, DB>,
     {
-        fn from_sql(bytes: Option<&DB::RawValue>) -> deserialize::Result<Self> {
+        fn from_sql(bytes: RawValue<DB>) -> deserialize::Result<Self> {
             <i32 as FromSql<Integer, DB>>::from_sql(bytes).map(|oid| TsConfiguration(oid as u32))
         }
     }


### PR DESCRIPTION
With recent changes to the Diesel API, some of the code in this crate no longer works. This PR addresses those breaking changes to unblock consumers who are relying on an unreleased version of Diesel but also need to use the TsVector type. I'm upgrading Diesel to a recent commit for now, and when the next major release of Diesel becomes available we can change the version of the `diesel` dep here to that new version and create a new release of this crate.