### PR TITLE
Only pull in 'postgres_backend' instead of 'postgres'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
           profile: minimal
           override: true
 
+      - uses: taiki-e/install-action@cargo-hack
       - name: Build crate
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
+        run: cargo hack --feature-powerset build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,4 @@ license = "MIT"
 repository = "https://github.com/diesel-rs/diesel_full_text_search"
 
 [dependencies]
-diesel = { version = "2.0.0", features = ["postgres"], default-features = false }
+diesel = { version = "2.0.0", features = ["postgres_backend"], default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,7 @@ repository = "https://github.com/diesel-rs/diesel_full_text_search"
 
 [dependencies]
 diesel = { version = "2.0.0", features = ["postgres_backend"], default-features = false }
+
+[features]
+default = ["with-diesel-postgres"]
+with-diesel-postgres = ["diesel/postgres"]


### PR DESCRIPTION
When used with `diesel-async`, this crate enables the `postgres` feature on `diesel` which causes it to pull in `libpq-sys`, while `postgres_backend` suffices for this crate 