### PR TITLE
Add `plainto_tsquery_with_search_config`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,10 @@ mod functions {
     sql_function!(fn length(x: TsVector) -> Integer);
     sql_function!(fn numnode(x: TsQuery) -> Integer);
     sql_function!(fn plainto_tsquery(x: Text) -> TsQuery);
+    sql_function! {
+        #[sql_name = "plainto_tsquery"]
+        fn plainto_tsquery_with_search_config(config: RegConfig, querytext: Text) -> TsQuery;
+    }
     sql_function!(fn querytree(x: TsQuery) -> Text);
     sql_function!(fn strip(x: TsVector) -> TsVector);
     sql_function!(fn to_tsquery(x: Text) -> TsQuery);


### PR DESCRIPTION
This PR adds `plainto_tsquery_with_search_config`, which respects `plainto_tsquery(config regconfig, query text ) → tsquery`.