### PR TITLE
Update `diesel` dependency to v2.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-      types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened]
   push:
     branches:
       - master
@@ -31,14 +31,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
 
       - name: Install ${{ matrix.version }}
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ matrix.version }}-${{ matrix.target }}
+          toolchain: ${{ matrix.version }}
           profile: minimal
-          override: true
 
       - uses: taiki-e/install-action@cargo-hack
       - name: Build crate

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel_full_text_search"
-version = "2.2.0"
+version = "2.3.0"
 description = "Adds support for PostgreSQL full text search to Diesel"
 license = "MIT"
 repository = "https://github.com/diesel-rs/diesel_full_text_search"
@@ -8,7 +8,7 @@ edition = "2021"
 
 [dependencies]
 byteorder = "1.5.0"
-diesel = { version = "~2.3.0", features = ["postgres_backend"], default-features = false }
+diesel = { version = "2.2.0", features = ["postgres_backend"], default-features = false }
 
 [features]
 default = ["with-diesel-postgres"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 
 [dependencies]
 byteorder = "1.5.0"
-diesel = { version = "~2.2.0", features = ["postgres_backend"], default-features = false }
+diesel = { version = "~2.3.0", features = ["postgres_backend"], default-features = false }
 
 [features]
 default = ["with-diesel-postgres"]


### PR DESCRIPTION
I ran the test suite locally and it seems like nothing broke between these versions. This should hopefully unblock crates.io from upgrading to v2.3 too :)

/cc @weiznich 