### PR TITLE
CI: Replace x86_64-apple-darwin target with aarch64-apple-darwin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,12 @@ jobs:
           - nightly
         target:
           - x86_64-unknown-linux-gnu
-          - x86_64-apple-darwin
+          - aarch64-apple-darwin
           - x86_64-pc-windows-msvc
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-          - target: x86_64-apple-darwin
+          - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-pc-windows-msvc
             os: windows-latest


### PR DESCRIPTION
GitHub Actions uses ARM runners by default these days. This should fix the currently broken CI workflow.

/cc @weiznich 